### PR TITLE
Added OS X Package directory to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A monokai theme for the [MarkdownEditing](https://github.com/SublimeText-Markdown/MarkdownEditing) package for Sublime Text 3 providing both **Coloured** and **text-style preview** for Markdown.
 
 ## Install
-Clone this repo (`git clone https://github.com/avivace/monokaiC`) and copy `ME-MonokaiC.tmTheme` to the Sublime Text User Package folder (`~/.config/sublime-text-3/Packages/User/` on Linux).
+Clone this repo (`git clone https://github.com/avivace/monokaiC`) and copy `ME-MonokaiC.tmTheme` to the Sublime Text User Package folder (`~/.config/sublime-text-3/Packages/User/` on Linux or `~/Library/Application\ Support/Sublime\ Text\ 3/Packages/User/` on OS X).
 
 Open your preferred MarkdownEditing User setting file from `Preferences > Package Settings >  Markdown Editing > Markdown (Standard) Settings - USER` (works with MultiMarkdown and Markdown GFM too).
 


### PR DESCRIPTION
I've added the Sublime package folder for OS X to the README instructions. Hope this is useful to you.

Thanks for a great project! The other styles for markdown in Sublime are terrible....