### PR TITLE
chapter/link/etc dark color #555555 is way too hard to read; causes eye strain -> increase contrast a little.

### DIFF
--- a/ME-MonokaiC.tmTheme
+++ b/ME-MonokaiC.tmTheme
@@ -327,7 +327,7 @@
                 <key>settings</key>
                 <dict>
                     <key>foreground</key>
-                    <string>#555555</string>
+                    <string>#989898</string>
                     <key>background</key>
                     <string>#131313</string>
                 </dict>
@@ -435,7 +435,7 @@
                 <key>settings</key>
                 <dict>
                     <key>foreground</key>
-                    <string>#555555</string>
+                    <string>#989898</string>
                     <key>background</key>
                     <string>#11111100</string>
                 </dict>
@@ -624,7 +624,7 @@
                 <dict>
                     <!--<key>background</key><string>#06cdcd</string>-->
                     <key>foreground</key>
-                    <string>#555555</string>
+                    <string>#989898</string>
                 </dict>
             </dict>
             <dict>
@@ -705,7 +705,7 @@
                     <key>background</key>
                     <string>#44444422</string>
                     <key>foreground</key>
-                    <string>#555555</string>
+                    <string>#989898</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
chapter/link/etc dark color #555555 is way too hard to read due to minimal contrast. Upped the contrast a little to reduce eye strain.

**Note**: the chosen color is much lighter as that reduces eye strain and improves readability of the markdown, but it's very close to the other white(ish) colors, so you might want to tweak it, either in color or brightness, to increase the visual difference with the other MD elements.
